### PR TITLE
docs: add CLAUDE.md and document architecture, scripts, and testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Read first
+
+- **`README.md`** — architecture overview, scripts/commands, local dev setup, env
+  vars, the Algolia and Contentful→Payload migration workflows, testing, and
+  deployment. Read it before acting; setup and architecture docs live there, not here.
+- [`~/.claude/docs/component-based-development.md`](~/.claude/docs/component-based-development.md) — UI/component conventions for this React/Next.js codebase.
+- [`~/.claude/docs/linting-and-formatting.md`](~/.claude/docs/linting-and-formatting.md) — ESLint / Prettier / remark / a11y tooling.
+
+## Behavioural rules
+
+- **After any schema/field change**, run `pnpm generate:payload-types` (and
+  `pnpm generate:importmap` if admin components changed) so `src/payload-types.ts`
+  stays in sync — much of the code imports its types from there.
+- **Do not bump `sharp` past Next's `^0.34.5` range.** A newer `sharp` adds a
+  second copy whose native libvips isn't traced into the Vercel function bundle,
+  500-ing every page in production. Keep the tree deduped to Next's version.
+- **Styling is CSS Modules** (`*.module.css`); the `@emotion/*` packages are
+  legacy. Do not add new emotion styles.
+- **Use the path aliases** (`@/*` → `src/*`, `@payload-config`, `@/payload-types`,
+  `@/i18n-config`) instead of relative paths.
+- **The two i18n layers are independent** — next-intl (public site, `src/messages/*.json`)
+  and Payload `localization` (content fields). Changing one does not change the other.
+- **Algolia indexing is in collection hooks** (`src/collections/hooks/algolia.ts`),
+  not a plugin; it no-ops without `ALGOLIA_*` env or when `DISABLE_ALGOLIA=true`.
+  After bulk DB changes, run `pnpm reindex:algolia` rather than relying on the hooks.

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,52 @@ Built with [Payload CMS](https://payloadcms.com/) (content + admin), [Next.js](h
 (framework, App Router, `en`/`de` via [next-intl](https://next-intl.dev/)) and
 [Algolia](https://www.algolia.com/) (search). Content lives in PostgreSQL.
 
+## Architecture
+
+Payload CMS is embedded in the Next.js App Router app — one process, one Postgres
+DB. The root config `src/payload.config.ts` (alias `@payload-config`) composes the
+modular pieces under `src/`: `collections`, `db.ts`, `jobs.ts`, `localization.ts`,
+`admin.ts`, `editor.ts`, `plugins.ts`.
+
+- **Route groups** (`src/app/`): `(frontend)` serves the public timeline under
+  `[locale]`; `(payload)` serves the admin UI and Payload's REST/GraphQL API.
+- **Data flow** is server-side: `(frontend)/[locale]/page.tsx` →
+  `fetchTimelineData(locale)` in `src/lib` (Payload local API) → `<Page>`. The
+  timeline does no client-side data fetching.
+- **Collections**: `media`, `event`, `time`, `person`, `user`. `event`/`time`/`person`
+  each relate an `image` to `media`.
+- **Two i18n layers**: next-intl for the public site (`en`/`de`, `src/messages/*.json`,
+  `src/i18n-config`, `src/utils/i18n.ts`) and Payload's own `localization` for
+  localized content fields. They are independent.
+- **Search**: Algolia is wired through collection `afterChange`/`afterDelete` hooks
+  (`src/collections/hooks/algolia.ts`), not a Payload plugin (`src/plugins.ts` is
+  empty). Records are bilingual (English doc + German `name`).
+- **DB**: `src/db.ts` normalizes the connection string's `sslmode` before the
+  postgres adapter. Schema auto-syncs in dev; production runs `payload migrate` in
+  the Vercel build.
+- **Styling**: CSS Modules (`*.module.css`) + `postcss-custom-media`. The
+  `@emotion/*` packages are legacy and unused in `src`.
+
+## Scripts
+
+```bash
+pnpm dev                       # Next.js + Payload admin, HTTPS on :3002
+pnpm build                     # next build
+pnpm lint-fix                  # eslint --fix + remark (run before building)
+pnpm test                      # test:types + test:int (vitest) + test:e2e + lint
+pnpm generate:payload-types    # regenerate src/payload-types.ts after schema changes
+pnpm generate:importmap        # regenerate the Payload admin import map
+pnpm migrate:create            # create a DB migration from current schema
+pnpm reindex:algolia           # rebuild all Algolia indices from the DB
+```
+
+Run a single test:
+
+```bash
+pnpm exec vitest run path/to/file.test.ts -t "test name"
+pnpm exec playwright test tests/e2e/home.spec.ts -g "renders"
+```
+
 ## Local development
 
 1. **Start the database** (Docker Postgres on port `5434`):
@@ -44,6 +90,30 @@ Indexing requires `ALGOLIA_APPLICATION_ID` and `ALGOLIA_ADMIN_API_KEY`; without 
 no-op. The browser search client reads the public app id + search key (`ALGOLIA_API_KEY`), which
 `next.config.js` exposes as `NEXT_PUBLIC_ALGOLIA_*`.
 
+## Testing
+
+```bash
+pnpm test          # test:types + test:int (vitest) + test:e2e (playwright) + lint
+pnpm test:e2e      # Playwright only
+```
+
+Locally, `test:e2e` runs against the dev server (`pnpm dev`, HTTPS). In CI
+(`.github/workflows/test.yml`) it runs against `pnpm start` (`next start`).
+
+A separate **post-deploy smoke gate** (`.github/workflows/smoke.yml`) runs on
+Vercel's `deployment_status` for every preview and production deploy: it points
+Playwright at the live deployment (`PLAYWRIGHT_BASE_URL` → `tests/smoke/`) and
+asserts `/de` and `/en` return HTTP 200. This catches failures that only appear
+in Vercel's bundled serverless runtime (e.g. function file-tracing dropping a
+native `.so`) — which `next start` cannot reproduce, since it has the full
+`node_modules` on disk.
+
+> **Do not bump `sharp` past Next's range.** Next.js pins `sharp@^0.34.5` as an
+> optional dependency. Installing a newer `sharp` adds a second copy whose
+> native libvips isn't traced into the Vercel function bundle, 500-ing every
+> page. Keep the direct `sharp` dependency within Next's range so the tree
+> dedupes to one copy.
+
 ## Content migration (Contentful → Payload)
 
 The one-time migration from the previous Contentful backend is captured in
@@ -62,3 +132,10 @@ Vercel/Neon integration automatically; add the app secrets (`PAYLOAD_SECRET`, `C
 `PREVIEW_SECRET`, the three `ALGOLIA_*` keys) in the Vercel project env. The Vercel build
 command runs `payload migrate` (against the unpooled URL) before `next build`. See
 `docs/database-setup.md` for the migration workflow.
+
+The post-deploy smoke gate (see [Testing](#testing)) needs no secret while
+preview deployments are public. If you enable Vercel Deployment Protection on
+previews, add a `VERCEL_AUTOMATION_BYPASS_SECRET` repo secret (Vercel → Project
+→ Deployment Protection → Protection Bypass for Automation) so the gate can
+reach protected URLs. To block bad builds before they merge, add the `smoke`
+job as a required status check on `main`.


### PR DESCRIPTION
## What

- **New `CLAUDE.md`** — read-first pointers (README + shared docs) and agent behavioural rules only. Setup and architecture stay in the README by convention.
- **README** gains:
  - **Architecture** — Payload-in-Next single process, `(frontend)`/`(payload)` route groups, server-side `fetchTimelineData` flow, the two independent i18n layers, Algolia-via-hooks, DB sslmode normalization, CSS Modules (emotion is legacy).
  - **Scripts** — common commands incl. single-test invocations and the `generate:payload-types` / `migrate:create` / `reindex:algolia` ones.
  - **Testing** — `pnpm test`, local-vs-CI e2e, and the post-deploy smoke gate (`deployment_status` → `tests/smoke/`).
  - A warning **not to bump `sharp` past Next's `^0.34.5` range** — the cause of the recent production 500s — plus a Production note on the smoke gate's optional bypass secret and merge-gating.

Docs-only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)